### PR TITLE
grep command doesn't work for a certificate chain file with more than…

### DIFF
--- a/ocsp_checker.sh
+++ b/ocsp_checker.sh
@@ -29,7 +29,7 @@ openssl s_client -showcerts -connect $URL:$PORT < /dev/null 2>&1 |  sed -n '/---
 TMP_CHAIN_CERT_FILE=$CHAIN_CERT_FILE.tmp
 
 #Removing the webpage certificate from the chain
-grep -Fvxf $DESTINATION_CERT_FILE $CHAIN_CERT_FILE > $TMP_CHAIN_CERT_FILE
+awk 'NR==FNR{a[$0]--;next} (++a[$0] > 0)' $DESTINATION_CERT_FILE $CHAIN_CERT_FILE > $TMP_CHAIN_CERT_FILE
 mv $TMP_CHAIN_CERT_FILE $CHAIN_CERT_FILE
 
 #Adding the HEADER and the FOOTER


### PR DESCRIPTION
… 2 certificates.

I tried this script to get the ocsp status but when the CHAIN_CERT_FILE had more than 2 certificates it failed to remove the web page certificate correctly. I replaced it with the awk command on line 32 and it worked great on different devices with different openssl version.